### PR TITLE
Frontend/feat/paddle

### DIFF
--- a/game/client/animation.js
+++ b/game/client/animation.js
@@ -3,9 +3,6 @@ import * as THREE from "three";
 let keyState = {};
 
 export function animate(scene, camera, composer, socket, paddleId) {
-  const paddleSpeed = 0.7;
-  const friction = 0.95; // 가속도 감소를 위한 마찰 계수
-  let paddleVelocity = 0;
   let paddleDirection = 0;
 
   const clock = new THREE.Clock();
@@ -77,20 +74,9 @@ export function animate(scene, camera, composer, socket, paddleId) {
 
     // 패들 움직임 처리
     const paddle = scene.getObjectByName(paddleId);
-    if (paddle) {
-      paddleVelocity += paddleDirection * paddleSpeed * deltaTime;
-      paddleVelocity *= friction; // 속도 감소를 위한 마찰 적용
-
-      // 패들 위치 업데이트
-      paddle.position.x += paddleVelocity;
-      // 패들이 화면 밖으로 나가지 않도록 제한
-      paddle.position.x = Math.max(
-        Math.min(paddle.position.x, 5 - 0.5),
-        -5 + 0.5
-      );
-
+    if (paddle && paddleDirection !== 0) {
       // 패들 위치 전송
-      socket.emit("paddleMove", { paddleId, position: paddle.position.x });
+      socket.emit("paddleMove", { paddleId, paddleDirection });
     }
 
     // 별 위치 업데이트

--- a/game/server/gameLogic.js
+++ b/game/server/gameLogic.js
@@ -86,13 +86,30 @@ function handlePaddleMove(roomName, data, io) {
   const room = rooms[roomName];
   if (!room) return;
 
-  const { paddleId, position } = data;
+  const { paddleId, paddleDirection } = data;
+
+  //방향값을 0.075, -0.075로 고정. (클라 쪽에서 악의적으로 큰 값이 들어올 수 있음)
+  let normalizedPaddleDirection;
+  if (paddleDirection != 0) {
+    normalizedPaddleDirection =
+      (paddleDirection * 0.075) / Math.abs(paddleDirection);
+  } else {
+    // 방향값이 0이면 패들을 움직이지 않기에 return
+    // 클라 쪽에서도 0이 들어오지 않을 것임
+    return;
+  }
+
+  const position = room.paddles[paddleId] + normalizedPaddleDirection;
+  console.log(paddleId, position);
   room.paddles[paddleId] = Math.max(
     -GAME_BOUNDS.x + PADDLE_WIDTH / 2,
     Math.min(GAME_BOUNDS.x - PADDLE_WIDTH / 2, position)
   );
 
-  io.to(roomName).emit("updatePaddle", { paddleId, position });
+  io.to(roomName).emit("updatePaddle", {
+    paddleId,
+    position: room.paddles[paddleId],
+  });
 }
 
 function resetGame(roomName, scorer, io) {


### PR DESCRIPTION
* 패들 이동 또한 서버 사이드 렌더링으로 구현했습니다.
* 패들 가속도를 삭제했습니다.
* 클라이언트 : 패들이 움직이지 않을 때는 이벤트를 아예 emit 하지 않도록 수정했습니다.
* 클라이언트 (위 아래 방향 전송) <-> 서버 (계산된 위치 전송)