### PR TITLE
refactor: nextGame 이벤트 추가 및 함수 구조 간결화

### DIFF
--- a/game/client/client.js
+++ b/game/client/client.js
@@ -17,137 +17,45 @@ let paddleId;
 let player1Score = 0;
 let player2Score = 0;
 
-// 디버그 : 방 번호 및 AI 모드 설정
-let DEBUG_ROOM_ID = 4242;
-const DEBUG_AI = false;
-let DEBUG_NEXT_OPPONENT = "TEST";
-
 let keyDownHandler;
 let keyUpHandler;
 
 let scene, camera, renderer, composer;
 
-// 게임 시작 함수
-function initGame() {
-  socket = io();
+socket = io();
+({ scene, camera, renderer, composer } = initScene(paddleId));
+createGeometry(scene);
 
-  socket.on("requestRoomId", () => {
-    socket.emit("roomId", { roomId: DEBUG_ROOM_ID, isAIMode: DEBUG_AI });
-  });
+window.addEventListener("resize", () => {
+  onWindowResize(camera, renderer, composer);
+});
 
-  keyDownHandler = (event) => handleKeyDown(event, paddleId);
-  keyUpHandler = (event) => handleKeyUp(event, paddleId);
-  window.addEventListener("keydown", keyDownHandler);
-  window.addEventListener("keyup", keyUpHandler);
+// 버튼 클릭 시 게임 재시작
+restartButton.addEventListener("click", () => {
+  if (restartButton.textContent === "나가기") {
+    window.history.back(); // 뒤로가기
+  } else if (restartButton.textContent === "다음 게임") {
+    socket.emit("nextGame"); // 다음 게임 시작
+    gameOverPopup.style.display = "none";
+  }
+});
 
+handleSocketEvents(socket, scene);
+
+function handleSocketEvents(socket, scene) {
   socket.on("init", (data) => {
     paddleId = data.paddleId;
-    ({ scene, camera, renderer, composer } = initScene(paddleId));
-    createGeometry(scene);
-    animate(scene, camera, composer, socket, paddleId);
-
-    updateScore(scene, player1Score, player2Score, paddleId);
-    handleSocketEvents(socket, scene);
-
-    window.addEventListener("resize", () => {
-      onWindowResize(camera, renderer, composer);
-    });
-  });
-
-  socket.on("disconnect", (reason) => {
-    console.log("서버와의 연결이 종료되었습니다.", reason);
-    alert(reason);
-  });
-}
-
-// nextGame 이벤트가 들어갈 함수
-// TODO : socket.io nextGame 함수 추가
-function restartGame() {
-  // 기존 애니메이션 중단
-  stopAnimation();
-
-  // 기존 소켓 연결 종료
-  if (socket) {
-    socket.off();
-    socket.disconnect();
-  }
-
-  // 디버그 : 방 번호 증가
-  // TODO : nextGame에서 어떻게 동작하는지 보고 수정
-  DEBUG_ROOM_ID += 1;
-  if (DEBUG_ROOM_ID === 4244) {
-    console.log("DEBUG_ROOM_ID is 4244");
-    DEBUG_NEXT_OPPONENT = "END";
-  }
-
-  socket = io();
-  socket.on("requestRoomId", () => {
-    socket.emit("roomId", { roomId: DEBUG_ROOM_ID, isAIMode: DEBUG_AI });
-  });
-
-  socket.on("init", (data) => {
-    paddleId = data.paddleId;
-
-    // 이벤트 제거 및 재등록
+    stopAnimation();
     if (keyDownHandler) window.removeEventListener("keydown", keyDownHandler);
     if (keyUpHandler) window.removeEventListener("keyup", keyUpHandler);
     keyDownHandler = (event) => handleKeyDown(event, paddleId);
     keyUpHandler = (event) => handleKeyUp(event, paddleId);
     window.addEventListener("keydown", keyDownHandler);
     window.addEventListener("keyup", keyUpHandler);
-
     resetGameObjects();
-
-    // ✅ 새로운 애니메이션 실행
     animate(scene, camera, composer, socket, paddleId);
   });
 
-  gameOverPopup.style.display = "none";
-}
-
-// ✅ 오브젝트(카메라, 점수판, 공과 패들) 위치 초기화 함수
-function resetGameObjects() {
-  const paddle1 = scene.getObjectByName("paddle1");
-  const paddle2 = scene.getObjectByName("paddle2");
-  const ball = scene.getObjectByName("ball");
-
-  if (paddle1) paddle1.position.set(0, -6.5, 0.2);
-  if (paddle2) paddle2.position.set(0, 6.5, 0.2);
-  if (ball) {
-    ball.position.set(0, 0, 0.2);
-    ball.vel = 0; // 속도 초기화
-  }
-
-  player1Score = 0;
-  player2Score = 0;
-  updateScore(scene, player1Score, player2Score, paddleId);
-  handleSocketEvents(socket, scene);
-
-  if (paddleId === "paddle1") {
-    camera.position.set(0, -10.5, 3);
-    camera.lookAt(0, 0, 1);
-  } else if (paddleId === "paddle2") {
-    camera.position.set(0, 10.5, 3);
-    camera.lookAt(0, 0, 1);
-    camera.rotation.z = Math.PI;
-  }
-}
-
-// 버튼 클릭 시 게임 재시작
-restartButton.addEventListener("click", () => {
-  if (restartButton.textContent === "나가기") {
-    // 뒤로 가기 동작
-    window.history.back();
-  } else if (restartButton.textContent === "다음 게임") {
-    // 다음 게임 시작
-    restartGame();
-  }
-});
-
-// 최초 게임 실행
-initGame();
-
-function handleSocketEvents(socket, scene) {
   socket.on("updatePaddle", (data) => {
     const paddle = scene.getObjectByName(data.paddleId);
     if (paddle) paddle.position.x = data.position;
@@ -166,14 +74,48 @@ function handleSocketEvents(socket, scene) {
     updateScore(scene, player1Score, player2Score, paddleId);
   });
 
-  socket.on("resetPositions", resetGameObjects);
+  socket.on("resetPositions", resetPositions);
 
   socket.on("gameOver", (data) => {
     showGameOver(
       data.winner === paddleId,
       data.paddle1,
       data.paddle2,
-      DEBUG_NEXT_OPPONENT
+      "data.opponents" // TODO : 해당 부분 백엔드 쪽에서 미구현
     );
   });
+
+  socket.on("disconnect", (reason) => {
+    console.log("서버와의 연결이 종료되었습니다.", reason);
+    alert(reason);
+  });
+}
+
+// 오브젝트(카메라, 점수판, 공과 패들) 초기화 함수 : 게임 시작할 때만 호출
+function resetGameObjects() {
+  resetPositions();
+  updateScore(scene, 0, 0, paddleId);
+
+  if (paddleId === "paddle1") {
+    camera.position.set(0, -10.5, 3);
+    camera.lookAt(0, 0, 1);
+  } else if (paddleId === "paddle2") {
+    camera.position.set(0, 10.5, 3);
+    camera.lookAt(0, 0, 1);
+    camera.rotation.z = Math.PI;
+  }
+}
+
+// 패들, 공 위치 초기화 함수 : 점수판 업데이트 시 호출
+function resetPositions() {
+  const paddle1 = scene.getObjectByName("paddle1");
+  const paddle2 = scene.getObjectByName("paddle2");
+  const ball = scene.getObjectByName("ball");
+
+  if (paddle1) paddle1.position.set(0, -6.5, 0.2);
+  if (paddle2) paddle2.position.set(0, 6.5, 0.2);
+  if (ball) {
+    ball.position.set(0, 0, 0.2);
+    ball.vel = 0;
+  }
 }

--- a/game/client/client.js
+++ b/game/client/client.js
@@ -23,7 +23,7 @@ let keyUpHandler;
 let scene, camera, renderer, composer;
 
 socket = io();
-({ scene, camera, renderer, composer } = initScene(paddleId));
+({ scene, camera, renderer, composer } = initScene());
 createGeometry(scene);
 
 window.addEventListener("resize", () => {

--- a/game/client/sceneSetup.js
+++ b/game/client/sceneSetup.js
@@ -4,7 +4,7 @@ import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
 
 //카메라 및 렌더러 초기화
-export function initScene(paddleId) {
+export function initScene() {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x000000);
 
@@ -14,16 +14,6 @@ export function initScene(paddleId) {
     0.1,
     1000
   );
-
-  // 카메라 위치 설정
-  if (paddleId === "paddle1") {
-    camera.position.set(0, -10.5, 3);
-    camera.lookAt(0, 0, 1);
-  } else if (paddleId === "paddle2") {
-    camera.position.set(0, 10.5, 3);
-    camera.lookAt(0, 0, 1);
-    camera.rotation.z = Math.PI;
-  }
 
   // 렌더러 설정
   const renderer = new THREE.WebGLRenderer({ antialias: true });


### PR DESCRIPTION
nextGame 이벤트 추가를 가정해서 client.js 코드를 전반적으로 고쳤습니다.

1. "init" 이벤트에 three.js를 렌더링을 하지 않고, paddleID에 영향을 받는 이벤트와 오브젝트 위치 등을 변경할 수 있도록 수정
2. 점수 업데이트 시 카메라 위치 등 불필요한 코드와 의도하지 않은 코드 삭제 및 함수 분리
3. 기타 디버그 코드들 삭제