### PR TITLE
hotfix: lose screen to winner in specific situation

### DIFF
--- a/backend/game/gameapp/connect_utils.py
+++ b/backend/game/gameapp/connect_utils.py
@@ -21,9 +21,6 @@ logger = logging.getLogger(__name__)
 def join_match(sid: str, match_user: "TempMatchUser", username: str):
     room_id = match_user.temp_match.id
     is_with_ai = match_user.temp_match.is_with_ai
-    # match_dict.set_if_not_exists(
-    #     room_id, Match(match_user.temp_match, is_with_ai=is_with_ai)
-    # )
 
     user = RealUser(is_ai=False, id=match_user.user.id, name=username, sid=sid)
     match_dict.user_connected(room_id, user)

--- a/frontend/game/client.js
+++ b/frontend/game/client.js
@@ -139,13 +139,15 @@ export const runPongGame = () => {
     socket.on("resetPositions", resetPositions);
 
     socket.on("gameOver", (data) => {
+      let win = data.winner === paddleId;
+      if (data.disconnect_win === true) win = true;
       setGameOver(true);
       showGameOver(
-        data.winner === paddleId,
+        win,
         data.paddle1,
         data.paddle2,
-        "unknown vs. unknown", // 기본값
-        false // 기본값
+        "", // 기본값
+        true // 기본값
       );
     });
 


### PR DESCRIPTION
파1 패배, 초1 진입, 초1 이탈, 파2 패배, 초2 진입 시 초2가 승리했으나, 화면에 패배로 뜨는 현상 수정